### PR TITLE
Support for Unicode search queries

### DIFF
--- a/ratebeer/ratebeer.py
+++ b/ratebeer/ratebeer.py
@@ -73,6 +73,11 @@ class RateBeer(object):
             Each list contains a dictionary of attributes of that brewery or
             beer.
         """
+        if isinstance(query,unicode):
+            query = query.encode('iso-8859-1')
+        else:
+            query = unicode(query,'UTF8').encode('iso-8859-1')
+            
         r = requests.post(RateBeer._BASE_URL + "/findbeer.asp",
                           data={"BeerName": query})
         soup = BeautifulSoup(r.text, "lxml")

--- a/ratebeer/ratebeer.py
+++ b/ratebeer/ratebeer.py
@@ -178,6 +178,14 @@ class RateBeer(object):
             brewed_at = brewery_info[0].findAll('a')[1]
 
         style = brewery_info[3]
+
+        if ',' in brewery_info[5]:
+            # Non-USA addresses
+            brewery_country = brewery_info[5].split(',')[1]
+        else:
+            # USA addresses
+            brewery_country = brewery_info[8]
+
         description = s_contents_rows[1].find_all('td')[1].find(
             'div', style=(
                 'border: 1px solid #e0e0e0; background: #fff; '
@@ -208,6 +216,8 @@ class RateBeer(object):
             output['brewed_at_url'] = brewed_at.get('href')
         if style:
             output['style'] = style.text.strip()
+        if brewery_country:
+            output['brewery_country'] = brewery_country.strip()
         if 'No commercial description' not in description.text:
             _ = [s.extract() for s in description('small')]
             output['description'] = ' '.join([s for s in description.strings]).strip()

--- a/test.py
+++ b/test.py
@@ -26,6 +26,7 @@ class TestSearch(unittest.TestCase):
             'name': u'New Belgium Tour de Fall',
             'brewery': u'New Belgium Brewing Company',
             'brewery_url': u'/brewers/new-belgium-brewing-company/77/',
+            'brewery_country': u'USA',
             'style': u'American Pale Ale',
             'ibu': 38
         }, results)
@@ -36,8 +37,20 @@ class TestSearch(unittest.TestCase):
             'name': u'Deschutes Inversion IPA',
             'brewery': u'Deschutes Brewery',
             'brewery_url': u'/brewers/deschutes-brewery/233/',
+            'brewery_country': u'USA',
             'style': u'India Pale Ale (IPA)',
             'ibu': 80
+        }, results)
+
+        results = RateBeer().beer("/beer/rochefort-trappistes-10/2360/")
+        self.assertIsNotNone(results)
+        self.assertDictContainsSubset({
+            'name': u'Rochefort Trappistes 10',
+            'brewery': u'Brasserie Rochefort',
+            'brewery_url': u'/brewers/brasserie-rochefort/406/',
+            'brewery_country': u'Belgium',
+            'style': u'Abt/Quadrupel',
+            'abv': 11.3
         }, results)
 
     def test_brewery(self):

--- a/test.py
+++ b/test.py
@@ -1,3 +1,5 @@
+#!/usr/local/bin/python
+# coding: utf-8
 import unittest
 
 from ratebeer import RateBeer
@@ -13,6 +15,17 @@ class TestSearch(unittest.TestCase):
             'name': u'Deschutes Inversion IPA',
             'id': '55610'
         }, results['beers'][0])
+
+        # Test a beer that requires encoding
+        results = RateBeer().search("to øl jule mælk")
+        self.assertListEqual(results['breweries'], [])
+        self.assertIsNotNone(results['beers'])
+        self.assertDictContainsSubset({
+            'url': '/beer/to-ol-jule-maelk/235066/',
+            'name': u'To Øl Jule Mælk',
+            'id': '235066'
+        }, results['beers'][0])
+
 
     def test_beer_404(self):
         rb = RateBeer()


### PR DESCRIPTION
RateBeer encodes its queries in ISO-8859-1, so I added a little check before the query to make sure the input string was also encoded as such.  

I also added parsing of the brewery's country off the the beer function. It's there and accessible, so why not? 