### PR TITLE
Fix issue when sending unicode encoded string to search()

### DIFF
--- a/ratebeer/ratebeer.py
+++ b/ratebeer/ratebeer.py
@@ -56,8 +56,9 @@ class RateBeer(object):
             Each list contains a dictionary of attributes of that brewery or
             beer.
         """
-        query = unicode(query, 'UTF8').encode('iso-8859-1')
-        if isinstance(query, unicode):
+        try:
+            query = unicode(query, 'UTF8').encode('iso-8859-1')
+        except TypeError:
             query = query.encode('iso-8859-1')
 
         request = requests.post(

--- a/test.py
+++ b/test.py
@@ -7,8 +7,8 @@ from ratebeer import rb_exceptions
 
 
 class TestSearch(unittest.TestCase):
-    def test_search(self):
-        ''' Test out the search function with a str search '''
+    def test_str_ascii_search(self):
+        ''' Test out the search function with an ASCII only str search '''
         results = RateBeer().search("deschutes inversion")
         self.assertListEqual(results['breweries'], [])
         self.assertIsNotNone(results['beers'])
@@ -18,9 +18,31 @@ class TestSearch(unittest.TestCase):
             'id': 55610
         }, results['beers'][0])
 
-    def test_unicode_search(self):
-        ''' Test out the search function with a unicode search '''
+    def test_unicode_ascii_search(self):
+        ''' Test out the search function with an ASCII only unicode search '''
+        results = RateBeer().search(u"deschutes inversion")
+        self.assertListEqual(results['breweries'], [])
+        self.assertIsNotNone(results['beers'])
+        self.assertDictContainsSubset({
+            'url': '/beer/deschutes-inversion-ipa/55610/',
+            'name': u'Deschutes Inversion IPA',
+            'id': 55610
+        }, results['beers'][0])
+
+    def test_str_nonascii_search(self):
+        ''' Test out the search function with a str with more than ASCII characters '''
         results = RateBeer().search("to øl jule mælk")
+        self.assertListEqual(results['breweries'], [])
+        self.assertIsNotNone(results['beers'])
+        self.assertDictContainsSubset({
+            'url': '/beer/to-ol-jule-maelk/235066/',
+            'name': u'To Øl Jule Mælk',
+            'id': 235066
+        }, results['beers'][0])
+
+    def test_unicode_nonascii_search(self):
+        ''' Test out the search function with a unicode string with more than ASCII characters '''
+        results = RateBeer().search(u"to øl jule mælk")
         self.assertListEqual(results['breweries'], [])
         self.assertIsNotNone(results['beers'])
         self.assertDictContainsSubset({


### PR DESCRIPTION
I merged your v2.0 commits with my local fork, hence the merge commit.  Feel free to reject the pull and add the fix as you see fit.

Basically my app currently sends a unicode string (e.g. ````u'To Øl Jule Mælk'```` rather than just ````'To Øl Jule Mælk'```` and the initial step in the search function fails if it's already encoded in unicode.