### PR TITLE
Support loading the alphabetic listing of breweries

### DIFF
--- a/test.py
+++ b/test.py
@@ -155,5 +155,15 @@ class TestSearch(unittest.TestCase):
         self.assertTrue(beer.name == u'To Øl Jule Mælk')
 
 
+class TestAlpha(unittest.TestCase):
+    def test_fetch_by_letter(self):
+        ''' Make sure the results for a brewery list by index contain the expected data '''
+        results = RateBeer().brewers_by_alpha("A")
+        self.assertIsNotNone(results, [])
+        beer = results[0]
+        self.assertTrue(beer.url == u'/brewers/a-duus-and-co/1668/')
+        self.assertTrue(beer.name == u'A. Duus & Co.')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
 from their dedicated pages on ratebeer.com.

I was looking for a way to build a temporary local cache of beer and brewery names, and it seemed easier to use the alphabetic listing of breweries than starting with the styles. So if you don't think this is useful, feel free to reject.

Hopefully the code makes sense - Python isn;t my native language so I tried to use the same structures and patterns already in the code.