### PR TITLE
Handle added icon in brewery location, fixing #28

### DIFF
--- a/ratebeer/ratebeer.py
+++ b/ratebeer/ratebeer.py
@@ -128,7 +128,7 @@ class RateBeer(object):
                 url = re.sub(r"\s+", "", url, flags=re.UNICODE)
                 brewer = models.Brewery(url)
                 brewer.name = row.a.string
-                brewer.location = row('td')[1].string.strip()
+                brewer.location = row('td')[1].text.strip()
                 output['breweries'].append(brewer)
         return output
 


### PR DESCRIPTION
Location cells for brewers include an icon (which is presumably new),
which means that the cell no longer has a .string.  Instead, as the icon
has no text, we use .text instead.