### PR TITLE
add support for a 'retired' property for beers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,7 @@ no key is required. Simply:
      'name': 'New Belgium Tour de Fall',
      'num_ratings': 257,
      'overall_rating': 77,
+     'retired': False,
      'seasonal': 'Autumn',
      'style': 'American Pale Ale',
      'style_rating': 75,
@@ -169,6 +170,7 @@ no key is required. Simply:
      'name': 'Summit Extra Pale Ale',
      'num_ratings': 701,
      'overall_rating': 67,
+     'retired': False,
      'seasonal': None,
      'style': 'American Pale Ale',
      'style_rating': 58,
@@ -223,6 +225,7 @@ no key is required. Simply:
    name)
 -  ``num_ratings`` (int): the number of reviews
 -  ``overall_rating`` (int): the overall rating (out of 100)
+-  ``retired`` (boolean): True if the beer is retired, otherwise False
 -  ``seasonal`` (string): Summer, Winter, Autumn, Spring, Series, Special, None
 -  ``style`` (string): beer style
 -  ``style_url`` (string): beer style URL

--- a/ratebeer/models.py
+++ b/ratebeer/models.py
@@ -175,6 +175,10 @@ class Beer(object):
             self.abv = float(soup.find(title="Alcohol By Volume").next_sibling.next_sibling.text[:-1])
         except ValueError: # Empty ABV: '-'
             self.abv = None
+        if soup.find(title="Currently out of production"):
+            self.retired = True
+        else:
+            self.retired = False
         # Description
         description = soup.find('div',
             style=(

--- a/ratebeer/ratebeer.py
+++ b/ratebeer/ratebeer.py
@@ -68,6 +68,7 @@ class RateBeer(object):
              'name': 'Summit Extra Pale Ale',
              'num_ratings': 701,
              'overall_rating': 67,
+             'retired': False,
              'seasonal': None,
              'style': 'American Pale Ale',
              'style_rating': 58,

--- a/test.py
+++ b/test.py
@@ -28,6 +28,7 @@ class TestBeer(unittest.TestCase):
         self.assertTrue(results['num_ratings'] >= 0)
         self.assertTrue(self.is_float(results['weighted_avg']))
         self.assertTrue(results['weighted_avg'] <= 5.0)
+        self.assertTrue(results['retired'] == False)
 
 
     def test_beer_404(self):
@@ -70,6 +71,11 @@ class TestBeer(unittest.TestCase):
         self.assertTrue(results['name'] == u'Steðji Októberbjór')
         self.assertTrue(results['brewery'].name == u'Brugghús Steðja')
         self.assertTrue(results['brewery'].url == u'/brewers/brugghus-steoja/15310/')
+
+    def test_beer_retired_beer(self):
+        ''' Attributes for retired beers display properly '''
+        results = RateBeer().beer('/beer/shorts-funkin-punkin/79468/')
+        self.assertTrue(results['retired'] == True)
 
 
 class TestBrewery(unittest.TestCase):


### PR DESCRIPTION
I wanted to be able to ignore actions on beers that weren't in production, so I added this. AFAIK the only case where the string `Currently out of production` appears is on retired beers, but if you have thoughts on a better way to identify them, I'm happy to adjust.