### PR TITLE
Encoding fix

### DIFF
--- a/ratebeer/soup.py
+++ b/ratebeer/soup.py
@@ -39,6 +39,8 @@ def _get_soup(url):
     if _BASE_URL in url:
         url.replace(_BASE_URL, '')
     req = requests.get(_BASE_URL + url, allow_redirects=True)
+    if '<meta http-equiv="Content-Type" content="text/html;" charset="utf-8">' in req.text:
+        req.encoding = 'utf-8'
     if "ratebeer robot oops" in req.text.lower():
         raise rb_exceptions.PageNotFound(url)
     return BeautifulSoup(req.text, "lxml")

--- a/test.py
+++ b/test.py
@@ -30,7 +30,7 @@ class TestBeer(unittest.TestCase):
         self.assertTrue(self.is_float(results['weighted_avg']))
         self.assertTrue(results['weighted_avg'] <= 5.0)
         self.assertTrue(results['retired'] == False)
-        self.assertTrue(results['description'] == u'New Belgium\'s love for beer, bikes and benefits is best described by being at Tour de Fat. Our love for Cascade and Amarillo hops is best tasted in our Tour de Fall Pale Ale. We\'re cruising both across the country during our favorite time of year. Hop on and find Tour de Fall Pale Ale in fall 2014.')
+        self.assertTrue(results['description'] == u'New Belgium’s love for beer, bikes and benefits is best described by being at Tour de Fat. Our love for Cascade and Amarillo hops is best tasted in our Tour de Fall Pale Ale. We’re cruising both across the country during our favorite time of year. Hop on and find Tour de Fall Pale Ale in fall 2014.')
 
     def test_beer_404(self):
         ''' Checks to make sure that we appropriately raise a page not found '''
@@ -98,7 +98,7 @@ class TestBeer(unittest.TestCase):
         self.assertIsNotNone(results)
         self.assertTrue(results['name'] == u'Steðji Októberbjór')
         self.assertTrue(results['brewery'].name == u'Brugghús Steðja')
-        self.assertTrue(results['brewery'].url == u'/brewers/brugghus-steoja/15310/')
+        self.assertTrue(results['brewery'].url == u'/brewers/brugghs-steja/15310/')
 
     def test_beer_retired_beer(self):
         ''' Attributes for retired beers display properly '''


### PR DESCRIPTION
It seems as though requests will default to ISO-8859-1 unless an encoding appears in both the  headers and the document's Content-Type ([see here](https://stackoverflow.com/a/36454703)). The problem @parryc noticed with the encodings being off in https://github.com/alilja/ratebeer/issues/43 seems to be due to the fact that some pages encoded UTF-8 but do not have the encoding specified in both the headers and the document. This fix hopefully corrects that issue.